### PR TITLE
Add test mocks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-globals",
   "description": "Functions and properties used globally across the FamilySearch site, available to web components.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "homepage": "https://github.com/fs-webdev/fs-globals",
   "author": {
     "name": "FamilySearch",

--- a/fs-globals-mock.js
+++ b/fs-globals-mock.js
@@ -1,0 +1,3 @@
+window.FS = window.FS || {};
+FS.User = FS.User || {};
+FS.User.sessionId = FS.User.sessionId || 'sessionId';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-globals",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Functions and properties used globally across the FamilySearch site, available to web components.",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Adding a file we can import in tests that mocks the parts of the FS object that we expect to get from the server. Right now this is just `FS.User.sessionId`, but in the future it could be more.